### PR TITLE
Fix:generate-python-code- remove plot a chart prompt-

### DIFF
--- a/pandasai/prompts/templates/generate_python_code.tmpl
+++ b/pandasai/prompts/templates/generate_python_code.tmpl
@@ -22,8 +22,5 @@ import pandas as pd
 Variable `dfs: list[pd.DataFrame]` is already declared.
 
 At the end, declare "result" variable as a dictionary of type and value.
-{% if viz_lib %}
-If you are asked to plot a chart, use "{{viz_lib}}" for charts, save as png.
-{% endif %}
 
 Generate python code and return full updated code:


### PR DESCRIPTION
Removing Metaplotlib library from prompt:- We don't need Metaplotlib to plot charts, because we are not plotting charts:- We just want agent to construct result in particular data format