### PR TITLE
Fix: Valueerror length of values does not match length of index

### DIFF
--- a/pandasai/helpers/data_sampler.py
+++ b/pandasai/helpers/data_sampler.py
@@ -39,7 +39,7 @@ class DataSampler:
         else:
             for col in self.df.columns:
                 col_sample = self._sample_column(col, n)
-                sampled_df[col] = col_sample
+                sampled_df[col] = pd.Series(col_sample)
 
         # anonymize the sampled dataframe head
         sampled_df = Anonymizer.anonymize_dataframe_head(sampled_df)


### PR DESCRIPTION
Context:- Skizaa AI was giving this error:-  Error occured during string conversion: Expecting value: line 1 column 1 (char 0)
2024-07-04 20:22:22 [ERROR] Error during analysis: string indices must be integers, not 'str'

Issue:- So when pandasAI tries to make sample data for LLM, and some column is not having 3 values(sample limit) or is completely empty, then while sampling it was throwing this error [https://stackoverflow.com/questions/42382263/valueerror-length-of-values-does-not-match-length-of-index-pandas-dataframe-u](url)

Fix: Converting column sample data to data series before assigning to dataframe will appened null values and rows number mismatch issue will go away